### PR TITLE
fix: automatic versioning and package publishing

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     branches:
       - main
-
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Enhanced the GitHub Actions CI/CD workflow to trigger on push events to the `main` branch and on tags that start with 'v'.
- Updated the release job to run not only on pushes to `main` but also on tags that start with 'v', improving the automation around versioning and package publishing.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-cd.yml</strong><dd><code>Enhance CI/CD Workflow Triggers and Release Conditions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-cd.yml
<li>Modified triggers for the workflow to run on push to <code>main</code> branch and <br>tags that start with 'v'.<br> <li> Adjusted the release job condition to trigger on push to <code>main</code> or tags <br>starting with 'v'.


</details>
    

  </td>
  <td><a href="https://github.com/thompsonson/det/pull/5/files#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4">+13/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

