### PR TITLE
fix: pyproject config for sementic-release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,9 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 det = "det.main:app"
+
+[tool.semantic_release]
+version_variable = "pyproject.toml:version"
+upload_to_pypi = true
+branch = "main"
+repository = "https://github.com/thompsonson/det"


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added configuration for semantic-release in `pyproject.toml`
- Set the `version_variable` to "pyproject.toml:version"
- Enabled uploading to PyPI
- Set the branch to "main"
- Set the repository URL to "https://github.com/thompsonson/det"


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Added configuration for semantic-release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml
<li>Added configuration for semantic-release<br> <li> Set the <code>version_variable</code> to "pyproject.toml:version"<br> <li> Enabled uploading to PyPI<br> <li> Set the branch to "main"<br> <li> Set the repository URL to "https://github.com/thompsonson/det"


</details>
    

  </td>
  <td><a href="https://github.com/thompsonson/det/pull/7/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

