### PR TITLE
fix: adding the PyPi token to poetry config

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,5 +74,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # This token is provided by Actions, no need to create it
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}  # This token should be created in PyPI and set in your repo's secrets
         run: |
+          poetry config pypi-token.pypi $PYPI_TOKEN
           poetry run semantic-release version
           poetry run semantic-release publish


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- This PR adds a command to the CI/CD workflow to configure the PyPI token in Poetry, ensuring that the semantic release process can publish packages to PyPI.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-cd.yml</strong><dd><code>Configure PyPI Token in Poetry for CI/CD Pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-cd.yml
<li>Added a command to configure the PyPI token in Poetry within the CI/CD <br>pipeline.<br>


</details>
    

  </td>
  <td><a href="https://github.com/thompsonson/det/pull/9/files#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

