### PR TITLE
fix: adding the GH token and setting the build command to not reinsta…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # This token is provided by Actions, no need to create it
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # This token is provided by Actions, no need to create it
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}  # This token should be created in PyPI and set in your repo's secrets
         run: |
           poetry config pypi-token.pypi $PYPI_TOKEN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,4 @@ major_on_zero = false
 branch = "main"
 upload_to_PyPI = true
 upload_to_release = true
-build_command = "make cicd_setup && make install && poetry build && poetry publish"
+build_command = "poetry build && poetry publish"


### PR DESCRIPTION
## **User description**
…ll poetry


___

## **Type**
enhancement


___

## **Description**
- Added `GH_TOKEN` to the Semantic Release job in GitHub Actions to ensure compatibility with tools requiring this specific environment variable.
- Simplified the `build_command` in `pyproject.toml` to improve build efficiency by removing unnecessary reinstallation of poetry and setup steps.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-cd.yml</strong><dd><code>Add GH_TOKEN to Semantic Release Job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-cd.yml
- Added `GH_TOKEN` environment variable to the Semantic Release job.



</details>
    

  </td>
  <td><a href="https://github.com/thompsonson/det/pull/10/files#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Simplify Build Command in pyproject.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml
<li>Simplified the <code>build_command</code> to exclude the reinstallation of poetry <br>and setup steps.<br>


</details>
    

  </td>
  <td><a href="https://github.com/thompsonson/det/pull/10/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

