### PR TITLE
feat(publish): automagic publishing of the python package

### DIFF
--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -1,3 +1,5 @@
+# CHANGELOG
+
 ## What's Changed
 {% for type_, commits in release["elements"] | dictsort %}
 ### {{ type_ | capitalize }}
@@ -5,3 +7,29 @@
 {% for commit in commits %}
 * {{ commit.descriptions[0] }} by {{commit.commit.author.name}} in [`{{ commit.short_hash }}`]({{ commit.hexsha | commit_hash_url }})
 {%- endfor %}{% endif %}{% endfor %}
+
+
+{% if context.history.unreleased | length > 0 %}
+
+{# UNRELEASED #}
+## Unreleased
+{% for type_, commits in context.history.unreleased | dictsort %}
+### {{ type_ | capitalize }}
+{% for commit in commits %}{% if type_ != "unknown" %}
+* {{ commit.commit.message.rstrip() }} ([`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+{% else %}
+* {{ commit.commit.message.rstrip() }} ([`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+{% endif %}{% endfor %}{% endfor %}
+
+{% endif %}
+
+{# RELEASED #}
+{% for version, release in context.history.released.items() %}
+## {{ version.as_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
+{% for type_, commits in release["elements"] | dictsort %}
+### {{ type_ | capitalize }}
+{% for commit in commits %}{% if type_ != "unknown" %}
+* {{ commit.commit.message.rstrip() }} ([`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+{% else %}
+* {{ commit.commit.message.rstrip() }} ([`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+{% endif %}{% endfor %}{% endfor %}{% endfor %}


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a comprehensive CHANGELOG template that categorizes changes into unreleased and released.
- Each section is further organized by change type, displaying commit messages, authors, and links to the commits for easy navigation.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md.j2</strong><dd><code>Enhanced CHANGELOG Template with Detailed Sections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/CHANGELOG.md.j2
<li>Added a CHANGELOG template structure including sections for unreleased <br>and released changes.<br> <li> Organized changes by type and included commit messages and authors.<br> <li> Provided links to commit hashes.


</details>
    

  </td>
  <td><a href="https://github.com/thompsonson/det/pull/12/files#diff-e84ecc893c951be4d8bad38f5324d4781e5cb59ec7df07ff88d140c58964b0ea">+28/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

