### PR TITLE
fix: patch update to trigger version 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,4 @@ major_on_zero = false
 branch = "main"
 upload_to_PyPI = true
 upload_to_release = true
-build_command = "poetry build && poetry publish"
+build_command = "poetry build"


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Removed the `poetry publish` command from the build process to modify the deployment strategy.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update Build Command in pyproject.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml
- Removed `poetry publish` from the build command.



</details>
    

  </td>
  <td><a href="https://github.com/thompsonson/det/pull/17/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

