### PR TITLE
fix: patch to give write permissions to the Action

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,6 +47,8 @@ jobs:
       run: make test
 
   release:
+    permissions:
+      contents: write
     needs: test
     runs-on: ubuntu-latest
     if: |


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added write permissions to the `release` job in the CI/CD workflow to ensure the action has the necessary permissions for its operations.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-cd.yml</strong><dd><code>Add write permissions to the release job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-cd.yml
- Added `permissions` with `contents: write` to the `release` job.



</details>
    

  </td>
  <td><a href="https://github.com/thompsonson/det/pull/18/files#diff-662dff05c7dfe6681c1007ae601e8573d413a03f9f9d53d951c2cb99caba4fd4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

